### PR TITLE
Update ClientEventHandler.java

### DIFF
--- a/src/main/java/kihira/tails/client/ClientEventHandler.java
+++ b/src/main/java/kihira/tails/client/ClientEventHandler.java
@@ -46,7 +46,7 @@ public class ClientEventHandler {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onPlayerRenderTick(RenderPlayerEvent.Specials.Pre e) {
     	UUID uuid = e.entityPlayer.getGameProfile().getId();
-        if (Tails.proxy.hasTailInfo(uuid) && Tails.proxy.getTailInfo(uuid).hastail && !e.entityPlayer.isInvisible()) {
+        if (uuid != null && Tails.proxy.hasTailInfo(uuid) && Tails.proxy.getTailInfo(uuid).hastail && !e.entityPlayer.isInvisible()) {
         	TailInfo info = Tails.proxy.getTailInfo(uuid);
         	
         	int type = info.typeid;


### PR DESCRIPTION
Added null check on UUIDs.
This should fix NullPointerEexceptions when dealing with FakeClientPlayers like BiblioCraft Armorstands.

I noticed this when making a custom armorstand (these need fake client players, because some armors like Thaumcraft's Fortress Armor check a players inventory to base certain elements of their render on).
Installed BiblioCraft and noticed the same exception, checked your code and found that a simple !=null should fix this^^
